### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/client/src/actions/index.tsx
+++ b/client/src/actions/index.tsx
@@ -751,6 +751,7 @@ export const toggleBlocking =
 
 export const toggleBlockingForClient = (type: any, domain: any, client: any) => {
     const escapedClientName = client
+        .replace(/\\/g, '\\\\')
         .replace(/'/g, "\\'")
         .replace(/"/g, '\\"')
         .replace(/,/g, '\\,')


### PR DESCRIPTION
Potential fix for [https://github.com/abpvn/AdGuardHome/security/code-scanning/1](https://github.com/abpvn/AdGuardHome/security/code-scanning/1)

To fix the issue, we need to ensure that backslashes in the `client` string are properly escaped before escaping other characters. This can be achieved by adding a `.replace(/\\/g, '\\\\')` call at the beginning of the chain of `replace` calls. This ensures that any backslashes in the input are doubled, preventing them from interfering with subsequent escaping or rule generation.

The updated code will:
1. Escape backslashes first to avoid conflicts with other escape sequences.
2. Continue escaping other characters (`'`, `"`, `,`, `|`) as before.

The fix will be applied to the `escapedClientName` definition on line 753.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
